### PR TITLE
Key optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ query.WHERE().EQUALS("location", "california").execute(function(err, result){ })
 
 ```
 var query = new Query(Cassanova.Client, Cassanova.Table("users"), "SELECT * FROM users");
-query.WHERE("firstname").IN(["john", "carl").execute(function(err, result){ });
+query.WHERE("firstname").IN(["john", "carl"]).execute(function(err, result){ });
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,12 @@ var query = new Query(Cassanova.Client, Cassanova.Table("users"), "SELECT * FROM
 query.WHERE().EQUALS("location", "california").execute(function(err, result){ });
 ```
 
+```
+var query = new Query(Cassanova.Client, Cassanova.Table("users"), "SELECT * FROM users");
+query.WHERE("firstname").IN(["john", "carl").execute(function(err, result){ });
+```
+
+
 There are a variety of ways that queries can be executed.
 
 #### Raw CQL via the Model
@@ -327,6 +333,9 @@ DELETE firstname, lastname FROM users;
 //.WHERE() - Chainable.
 WHERE
 
+//.WHERE(key) - Chainable
+WHERE firstname
+
 //.WHERE_EQUALS(key, value) - Chainable.
 WHERE firstname = 'james';
 
@@ -335,6 +344,9 @@ firstname = 'james'
 
 //.AND() - Chainable.
 AND
+
+//.AND(key) - Chainable.
+AND firstname
 
 //.GT(key, value) - Chainable.
 age > 21
@@ -350,6 +362,9 @@ age <= 21
 
 //.IN(options) - Chainable. A single value or an Array of values.
 IN (123, 456);
+
+//.IN(key, options) - Chainable. Optional key parameter.
+userid IN (123, 456)
 
 //.LIMIT(value) - Chainable.
 LIMIT 10

--- a/lib/query.js
+++ b/lib/query.js
@@ -281,8 +281,13 @@ Query.prototype.DELETE = function(selector){
  * Chainable, adds "WHERE" into the CQL statement.
  * WHERE
  */
-Query.prototype.WHERE = function(){
-    this.cql_str += "WHERE ";
+Query.prototype.WHERE = function(key){
+    if(key) {
+        Query.utils.verifySchemaKey(key, null, this, true);
+        this.cql_str += "WHERE " + key + " ";
+    } else {
+        this.cql_str += "WHERE ";
+    }
 
     return this;
 };
@@ -316,8 +321,13 @@ Query.prototype.EQUALS = function(key, value){
  * Chainable, adds "AND" into the CQL statement.
  * AND
  */
-Query.prototype.AND = function(){
-    this.cql_str += "AND ";
+Query.prototype.AND = function(key){
+    if(key) {
+        Query.utils.verifySchemaKey(key, null, this, true);
+        this.cql_str += "AND " + key + " ";
+    } else {
+        this.cql_str += "AND ";
+    }
 
     return this;
 };
@@ -374,15 +384,25 @@ Query.prototype.LTE = function(key, value){
  * Chainable, adds "IN" into the CQL statement.
  * IN (123, 456)
  */
-Query.prototype.IN = function(options){
+Query.prototype.IN = function(key, options){
     var inOpt = [];
+
+    if(arguments.length === 1) {
+        options = key;
+        key = null;
+    }
 
     if(!options){
         throw new Error("The predicate IN requires and Array argument.");
     }
     inOpt = Array.isArray(options) ? options : [options];
     inOpt = Query.utils.checkQuoteNeeds(inOpt);
-    this.cql_str += "IN (" + inOpt.join(", ") + ")";
+    if(key) {
+        Query.utils.verifySchemaKey(key, null, this, true);
+        this.cql_str += key + " IN (" + inOpt.join(", ") + ")";
+    } else {
+        this.cql_str += "IN (" + inOpt.join(", ") + ")";
+    }
 
     return this;
 };

--- a/test/QueryTest.js
+++ b/test/QueryTest.js
@@ -180,6 +180,14 @@ describe("Cassanova Query Tests", function(){
             (query.toString()).should.equal("SELECT * FROM users WHERE userid = 'abcdefg';");
             done();
         });
+        it("Should create a SELECT query with a WHERE and a optional `key` argument.", function(done){
+            var query = new Query(baseTable);
+
+            query.SELECT("*", "users").WHERE("userid").IN([123, 456]);
+
+            (query.toString()).should.equal("SELECT * FROM users WHERE userid IN (123, 456);");
+            done();
+        });
         it("Should create a SELECT query with a WHERE_EQUALS shortcut", function(done){
             var query = new Query(baseTable);
 
@@ -203,6 +211,14 @@ describe("Cassanova Query Tests", function(){
             query.SELECT(['firstname', 'lastname']).WHERE_EQUALS("firstname", "james").AND().EQUALS("age", 37);
 
             (query.toString()).should.eql("SELECT firstname, lastname FROM users WHERE firstname = 'james' AND age = 37;");
+            done();
+        });
+        it("Should create a valid SELECT statement with WHERE, AND with optional key paramater, IN", function(done) {
+            var query = new Query(baseTable);
+
+            query.SELECT(['firstname', 'lastname']).WHERE_EQUALS("firstname", "james").AND("userid").IN([123, 456]);
+
+            (query.toString()).should.eql("SELECT firstname, lastname FROM users WHERE firstname = 'james' AND userid IN (123, 456);");
             done();
         });
         it("Should create a valid SELECT statement with WHERE, IN (non-array)", function(done) {
@@ -244,6 +260,14 @@ describe("Cassanova Query Tests", function(){
             query.SELECT(['firstname', 'lastname']).WHERE_EQUALS("firstname", "james").IN(['state','country']);
 
             (query.toString()).should.eql("SELECT firstname, lastname FROM users WHERE firstname = 'james' IN ('state', 'country');");
+            done();
+        });
+        it("Should create a valid SELECT statement with WHERE, IN (optional key parameter)", function(done) {
+            var query = new Query(baseTable);
+
+            query.SELECT(['firstname', 'lastname']).WHERE().IN("userid", [123, 456]);
+
+            (query.toString()).should.eql("SELECT firstname, lastname FROM users WHERE userid IN (123, 456);");
             done();
         });
         it("Should create a valid SELECT statement with WHERE, AND, GT", function(done) {


### PR DESCRIPTION
This adds support for an optional ````key```` parameter for the ````WHERE````, ````AND````, ````IN```` query methods, so we can do things like:

````query.SELECT("*").WHERE("userid").IN([1, 2, 3]);````
````query.SELECT("fname").WHERE_EQUALS("country", "france").AND("profession").IN(["engineer", "doctor", "teacher"]);````